### PR TITLE
Implemented io.toInputStream: Process[Task, Array[Byte]] => InputStream

### DIFF
--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -318,6 +318,7 @@ object io {
     def step(): Unit = {
       if (stack.isEmpty) {
         halted = true
+        chunks = null     // release things
       } else {
         val item = stack.head(cause).run
         stack = stack.tail

--- a/src/test/scala/scalaz/stream/ToInputStreamSpec.scala
+++ b/src/test/scala/scalaz/stream/ToInputStreamSpec.scala
@@ -1,0 +1,102 @@
+package scalaz.stream
+
+import org.scalacheck._
+import Prop._
+
+import scalaz.concurrent.Task
+
+import java.io.DataInputStream
+
+object ToInputStreamSpec extends Properties("toInputStream") {
+
+  property("handles arbitrary emitAll") = forAll { bytes: List[List[Byte]] =>
+    val length = bytes map { _.length } sum
+    val p = Process emitAll bytes
+
+    val dis = new DataInputStream(io.toInputStream(p) { _.toArray })
+    val buffer = new Array[Byte](length)
+    dis.readFully(buffer)
+    dis.close()
+
+    List(buffer: _*) == bytes.flatten
+  }
+
+  property("handles appended emits") = forAll { bytes: List[List[Byte]] =>
+    val length = bytes map { _.length } sum
+    val p = bytes map Process.emit reduceOption { _ ++ _ } getOrElse Process.empty
+
+    val dis = new DataInputStream(io.toInputStream(p) { _.toArray })
+    val buffer = new Array[Byte](length)
+    dis.readFully(buffer)
+    dis.close()
+
+    List(buffer: _*) == bytes.flatten
+  }
+
+  property("handles await") = forAll { chunk: List[Byte] =>
+    val length = chunk.length
+
+    val p = Process.await(Task now (())) { _ =>
+      Process emit chunk
+    }
+
+    val dis = new DataInputStream(io.toInputStream(p) { _.toArray })
+    val buffer = new Array[Byte](length)
+    dis.readFully(buffer)
+    dis.close()
+
+    buffer.toList == chunk
+  }
+
+  property("handles appended awaits") = forAll { bytes: List[List[Byte]] =>
+    val length = bytes map { _.length } sum
+
+    val p = bytes map { data =>
+      Process.await(Task now (())) { _ =>
+        Process emit data
+      }
+    } reduceOption { _ ++ _ } getOrElse Process.empty
+
+    val dis = new DataInputStream(io.toInputStream(p) { _.toArray })
+    val buffer = new Array[Byte](length)
+    dis.readFully(buffer)
+    dis.close()
+
+    List(buffer: _*) == bytes.flatten
+  }
+
+  property("handles one append within an await") = secure {
+    val bytes: List[List[List[Byte]]] = List(List(), List(List(127)))
+    val length = bytes map { _ map { _.length } sum } sum
+
+    val p = bytes map { data =>
+      Process.await(Task now (())) { _ =>
+        data map Process.emit reduceOption { _ ++ _ } getOrElse Process.empty
+      }
+    } reduceOption { _ ++ _ } getOrElse Process.empty
+
+    val dis = new DataInputStream(io.toInputStream(p) { _.toArray })
+    val buffer = new Array[Byte](length)
+    dis.readFully(buffer)
+    dis.close()
+
+    List(buffer: _*) == (bytes flatMap { _.flatten })
+  }
+
+  property("handles appends within awaits") = forAll { bytes: List[List[List[Byte]]] =>
+    val length = bytes map { _ map { _.length } sum } sum
+
+    val p = bytes map { data =>
+      Process.await(Task now (())) { _ =>
+        data map Process.emit reduceOption { _ ++ _ } getOrElse Process.empty
+      }
+    } reduceOption { _ ++ _ } getOrElse Process.empty
+
+    val dis = new DataInputStream(io.toInputStream(p) { _.toArray })
+    val buffer = new Array[Byte](length)
+    dis.readFully(buffer)
+    dis.close()
+
+    List(buffer: _*) == (bytes flatMap { _.flatten })
+  }
+}


### PR DESCRIPTION
Hurray for Java! There are a couple of very nice things about this implementation:
- Support for early termination via `close()` (all finalizers will run)
- In theory, somewhat faster than implementations on top of `toTask`
- ROAR TESTS!
- Somewhat more flexible chunking support

The actual signature of the method is as follows:

``` scala
def toInputStream[A](p: Process[Task, A])(chunk: A => Array[Byte]): InputStream
```

This gives some wiggle room in terms of the types within the process, allowing
for things like `ByteBuffer` and such.  An even _more_ interesting type signature
signature would be the following:

``` scala
def toInputStream[A](p: Process[Task, A])(copy: (A, Array[Byte], Int, Int]) => Unit): InputStream
```

This type signature is nice because it eliminates garbage intermediate chunk
storage.  If your stream does not contain byte arrays, and you have no need
to manipulate byte arrays (e.g. when your stream actually contains direct
`ByteBuffer`(s)), then this signature will allow one-copy streaming into the
resulting `InputStream`.  I can't bring myself to type that signature with a
straight face though, because it really is awful.

In other news, this addresses the only major `toTask` use-case raised in #317.
